### PR TITLE
add-agency-full-name-field-in-agency-totals-year-route

### DIFF
--- a/main.go
+++ b/main.go
@@ -65,8 +65,12 @@ func getTotalsOfAgencyYear(c echo.Context) error {
 		log.Printf("[totals of agency year] error getting data for first screen(ano:%d, estado:%s):%q", year, aID, err)
 		return c.JSON(http.StatusBadRequest, fmt.Sprintf("Parâmetro ano=%d ou orgao=%s inválidos", year, aID))
 	}
+	agency, err := client.Db.GetAgency(aID)
+	if err != nil {
+		log.Printf("[totals of agency year] error getting data for first screen(estado:%s):%q", aID, err)
+		return c.JSON(http.StatusBadRequest, fmt.Sprintf("Parâmetro orgao=%s inválido", aID))
+	}
 	var monthTotalsOfYear []models.MonthTotals
-
 	for _, agencyMonthlyInfo := range agenciesMonthlyInfo[aID] {
 		if agencyMonthlyInfo.Summary.MemberActive.Wage.Total+agencyMonthlyInfo.Summary.MemberActive.Perks.Total+agencyMonthlyInfo.Summary.MemberActive.Others.Total > 0 {
 			monthTotals := models.MonthTotals{Month: agencyMonthlyInfo.Month,
@@ -80,7 +84,7 @@ func getTotalsOfAgencyYear(c echo.Context) error {
 	sort.Slice(monthTotalsOfYear, func(i, j int) bool {
 		return monthTotalsOfYear[i].Month < monthTotalsOfYear[j].Month
 	})
-	agencyTotalsYear := models.AgencyTotalsYear{Year: year, MonthTotals: monthTotalsOfYear}
+	agencyTotalsYear := models.AgencyTotalsYear{Year: year, MonthTotals: monthTotalsOfYear, AgencyFullName: agency.Name}
 	return c.JSON(http.StatusOK, agencyTotalsYear)
 }
 

--- a/models/models.go
+++ b/models/models.go
@@ -52,8 +52,9 @@ type AgencySummary struct {
 
 // AgencyTotalsYear - Represents the totals of an year
 type AgencyTotalsYear struct {
-	Year        int
-	MonthTotals []MonthTotals
+	Year           int
+	MonthTotals    []MonthTotals
+	AgencyFullName string
 }
 
 // MonthTotals - Detailed info of a month (wage, perks, other)


### PR DESCRIPTION
Esse PR
* insere o nome completo da agencia como uma propriedade para o tipo AgencyTotalsYear
* retorna na rota de totais o nome completo da agencia para ser usado no front