### PR TITLE
Improvements for errors in api

### DIFF
--- a/main.go
+++ b/main.go
@@ -187,27 +187,6 @@ func getSummaryOfAgency(c echo.Context) error {
 	return c.JSON(http.StatusOK, agencySummary)
 }
 
-func verifyNextOMA(month int, year int, agencyName string) bool {
-	if month == 12 {
-		month = 1
-		year += 1
-	} else {
-		month += 1
-	}
-	_, _, err := client.GetOMA(month, year, agencyName)
-	return err == nil
-}
-func verifyPreviousOMA(month int, year int, agencyName string) bool {
-	if month == 1 {
-		month = 12
-		year -= 1
-	} else {
-		month -= 1
-	}
-	_, _, err := client.GetOMA(month, year, agencyName)
-	return err == nil
-}
-
 func generalSummaryHandler(c echo.Context) error {
 	agencyAmount, err := client.GetAgenciesCount()
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -181,8 +181,8 @@ func getSummaryOfAgency(c echo.Context) error {
 			agencyMonthlyInfo.Summary.OtherRemunerations.Total,
 		TotalMembers: agencyMonthlyInfo.Summary.Count,
 		CrawlingTime: agencyMonthlyInfo.CrawlingTimestamp,
-		HasNext:      verifyNextOMA(month, year, agencyName),
-		HasPrevious:  verifyPreviousOMA(month, year, agencyName),
+		HasNext:      time.Date(year, time.Month(month), 1, 0, 0, 0, 0, time.UTC).In(loc).Before(time.Now().Add(time.Hour * 24)),
+		HasPrevious:  time.Date(year, time.Month(month), 1, 0, 0, 0, 0, time.UTC).In(loc).After(time.Date(2018, 1, 1, 0, 0, 0, 0, time.UTC).In(loc)),
 	}
 	return c.JSON(http.StatusOK, agencySummary)
 }
@@ -319,34 +319,27 @@ func getMonthlyInfo(c echo.Context) error {
 		MemberActive Summary `json:"membros_ativos,omitempty"`
 	}
 
-	type SummaryzedMI struct {
-		AgencyID string    `json:"id_orgao,omitempty"`
-		Month    int       `json:"mes,omitempty"`
-		Year     int       `json:"ano,omitempty"`
-		Summary  Summaries `json:"sumarios,omitempty"`
-		Package  Backup    `json:"pacote_de_dados,omitempty"`
-	}
 	type MIError struct {
 		ErrorMessage string `json:"err_msg,omitempty"`
 		Status       int32  `json:"status,omitempty"`
 		Cmd          string `json:"cmd,omitempty"`
 	}
+	type SummaryzedMI struct {
+		AgencyID string     `json:"id_orgao,omitempty"`
+		Month    int        `json:"mes,omitempty"`
+		Year     int        `json:"ano,omitempty"`
+		Summary  *Summaries `json:"sumarios,omitempty"`
+		Package  *Backup    `json:"pacote_de_dados,omitempty"`
+		Error    *MIError   `json:"error,omitempty"`
+	}
 	var summaryzedMI []SummaryzedMI
 	for i := range monthlyInfo {
-		// Verify if there's only one MI and there's an error, to return this error in mi by month route in api
-		if len(monthlyInfo[i]) == 1 && monthlyInfo[i][0].ProcInfo != nil && month != "" {
-			return c.JSON(http.StatusPartialContent, MIError{
-				ErrorMessage: monthlyInfo[i][0].ProcInfo.Stderr,
-				Status:       monthlyInfo[i][0].ProcInfo.Status,
-				Cmd:          monthlyInfo[i][0].ProcInfo.Cmd,
-			})
-		}
 		for _, mi := range monthlyInfo[i] {
 			if mi.ProcInfo == nil {
-				summaryzedMI = append(summaryzedMI, SummaryzedMI{AgencyID: mi.AgencyID, Month: mi.Month, Year: mi.Year, Package: Backup{
+				summaryzedMI = append(summaryzedMI, SummaryzedMI{AgencyID: mi.AgencyID, Error: nil, Month: mi.Month, Year: mi.Year, Package: &Backup{
 					URL:  formatDownloadUrl(mi.Package.URL),
 					Hash: mi.Package.Hash,
-				}, Summary: Summaries{
+				}, Summary: &Summaries{
 					MemberActive: Summary{
 						Count: mi.Summary.Count,
 						BaseRemuneration: DataSummary{
@@ -363,6 +356,12 @@ func getMonthlyInfo(c echo.Context) error {
 						},
 					},
 				}})
+			} else {
+				summaryzedMI = append(summaryzedMI, SummaryzedMI{AgencyID: mi.AgencyID, Error: &MIError{
+					ErrorMessage: monthlyInfo[i][0].ProcInfo.Stderr,
+					Status:       monthlyInfo[i][0].ProcInfo.Status,
+					Cmd:          monthlyInfo[i][0].ProcInfo.Cmd,
+				}, Month: mi.Month, Year: mi.Year, Package: nil, Summary: nil})
 			}
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -188,7 +188,7 @@ func getSummaryOfAgency(c echo.Context) error {
 			agencyMonthlyInfo.Summary.OtherRemunerations.Total,
 		TotalMembers: agencyMonthlyInfo.Summary.Count,
 		CrawlingTime: agencyMonthlyInfo.CrawlingTimestamp,
-		HasNext:      time.Date(year, time.Month(month), 1, 0, 0, 0, 0, time.UTC).In(loc).Before(time.Now().Add(time.Hour * 24)),
+		HasNext:      time.Date(year, time.Month(month), 1, 0, 0, 0, 0, time.UTC).In(loc).Before(time.Now().AddDate(0, 1, 0)),
 		HasPrevious:  time.Date(year, time.Month(month), 1, 0, 0, 0, 0, time.UTC).In(loc).After(time.Date(2018, 1, 1, 0, 0, 0, 0, time.UTC).In(loc)),
 	}
 	return c.JSON(http.StatusOK, agencySummary)

--- a/main.go
+++ b/main.go
@@ -84,6 +84,13 @@ func getTotalsOfAgencyYear(c echo.Context) error {
 				OtherRemunerations: agencyMonthlyInfo.Summary.OtherRemunerations.Total,
 			}
 			monthTotalsOfYear = append(monthTotalsOfYear, monthTotals)
+		} else if agencyMonthlyInfo.ProcInfo != nil {
+			monthTotals := models.MonthTotals{Month: agencyMonthlyInfo.Month,
+				BaseRemuneration:   0,
+				OtherRemunerations: 0,
+				Error:              agencyMonthlyInfo.ProcInfo,
+			}
+			monthTotalsOfYear = append(monthTotalsOfYear, monthTotals)
 		}
 	}
 	sort.Slice(monthTotalsOfYear, func(i, j int) bool {

--- a/models/models.go
+++ b/models/models.go
@@ -62,6 +62,7 @@ type AgencyTotalsYear struct {
 
 // MonthTotals - Detailed info of a month (wage, perks, other)
 type MonthTotals struct {
+	Error              *coleta.ProcInfo
 	Month              int
 	BaseRemuneration   float64
 	OtherRemunerations float64


### PR DESCRIPTION
Esse PR:

* usa o esquema proposto para envios de erro na api publica
* obtém a previous e next date no lado do servidor
* remove funções de geração de data não mais usadas
* adiciona o campo de erro na listagem de remunerações por ano no frontend para ser usado na legenda