### PR TITLE
Médias por mês e per capita

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1330,10 +1330,22 @@ const docTemplate = `{
                 "outras_remuneracoes": {
                     "type": "number"
                 },
+                "outras_remuneracoes_por_mes": {
+                    "type": "number"
+                },
+                "outras_remuneracoes_por_membro": {
+                    "type": "number"
+                },
                 "package": {
                     "$ref": "#/definitions/uiapi.backup"
                 },
                 "remuneracao_base": {
+                    "type": "number"
+                },
+                "remuneracao_base_por_mes": {
+                    "type": "number"
+                },
+                "remuneracao_base_por_membro": {
                     "type": "number"
                 }
             }
@@ -1603,7 +1615,13 @@ const docTemplate = `{
                 "outras_remuneracoes": {
                     "type": "number"
                 },
+                "outras_remuneracoes_por_membro": {
+                    "type": "number"
+                },
                 "remuneracao_base": {
+                    "type": "number"
+                },
+                "remuneracao_base_por_membro": {
                     "type": "number"
                 },
                 "timestamp": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1320,10 +1320,22 @@
                 "outras_remuneracoes": {
                     "type": "number"
                 },
+                "outras_remuneracoes_por_mes": {
+                    "type": "number"
+                },
+                "outras_remuneracoes_por_membro": {
+                    "type": "number"
+                },
                 "package": {
                     "$ref": "#/definitions/uiapi.backup"
                 },
                 "remuneracao_base": {
+                    "type": "number"
+                },
+                "remuneracao_base_por_mes": {
+                    "type": "number"
+                },
+                "remuneracao_base_por_membro": {
                     "type": "number"
                 }
             }
@@ -1593,7 +1605,13 @@
                 "outras_remuneracoes": {
                     "type": "number"
                 },
+                "outras_remuneracoes_por_membro": {
+                    "type": "number"
+                },
                 "remuneracao_base": {
+                    "type": "number"
+                },
+                "remuneracao_base_por_membro": {
                     "type": "number"
                 },
                 "timestamp": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -249,9 +249,17 @@ definitions:
         type: integer
       outras_remuneracoes:
         type: number
+      outras_remuneracoes_por_mes:
+        type: number
+      outras_remuneracoes_por_membro:
+        type: number
       package:
         $ref: '#/definitions/uiapi.backup'
       remuneracao_base:
+        type: number
+      remuneracao_base_por_mes:
+        type: number
+      remuneracao_base_por_membro:
         type: number
     type: object
   uiapi.backup:
@@ -431,7 +439,11 @@ definitions:
         type: integer
       outras_remuneracoes:
         type: number
+      outras_remuneracoes_por_membro:
+        type: number
       remuneracao_base:
+        type: number
+      remuneracao_base_por_membro:
         type: number
       timestamp:
         $ref: '#/definitions/uiapi.timestamp'

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/dadosjusbr/proto v0.0.0-20221212025627-91c60aa3cd12
-	github.com/dadosjusbr/storage v0.0.0-20230413185823-e1bb61c2aff7
+	github.com/dadosjusbr/storage v0.0.0-20230420170502-31dc5a2caf92
 	github.com/gocarina/gocsv v0.0.0-20220712153207-8b2118da4570
 	github.com/golang/mock v1.6.0
 	github.com/joho/godotenv v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -41,6 +41,8 @@ github.com/dadosjusbr/storage v0.0.0-20230324163923-06fe8b397297 h1:umyiExgyaJt1
 github.com/dadosjusbr/storage v0.0.0-20230324163923-06fe8b397297/go.mod h1:ttc45wBL5bjz5uU24mgNNPV9ZHaJ3SmoRwVOmyVRZyY=
 github.com/dadosjusbr/storage v0.0.0-20230413185823-e1bb61c2aff7 h1:Fk8O0T88k8Lxqi5HcZFZ45tV+Luwk4ruT08IyTe82YY=
 github.com/dadosjusbr/storage v0.0.0-20230413185823-e1bb61c2aff7/go.mod h1:ttc45wBL5bjz5uU24mgNNPV9ZHaJ3SmoRwVOmyVRZyY=
+github.com/dadosjusbr/storage v0.0.0-20230420170502-31dc5a2caf92 h1:73BiNvlognV5PGCy6fWxa7T8QTxl8R84sU/hWC0ulKA=
+github.com/dadosjusbr/storage v0.0.0-20230420170502-31dc5a2caf92/go.mod h1:ttc45wBL5bjz5uU24mgNNPV9ZHaJ3SmoRwVOmyVRZyY=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/uiapi/handlers.go
+++ b/uiapi/handlers.go
@@ -336,10 +336,6 @@ func (h handler) V2GetTotalsOfAgencyYear(c echo.Context) error {
 			// The status 4 is a report from crawlers that data is unavailable or malformed. By removing them from the API results, we make sure they are displayed as if there is no data.
 		} else if agencyMonthlyInfo.ProcInfo.String() != "" && agencyMonthlyInfo.ProcInfo.Status != 4 {
 			monthTotals := v2MonthTotals{Month: agencyMonthlyInfo.Month,
-				BaseRemuneration:            0,
-				OtherRemunerations:          0,
-				BaseRemunerationPerCapita:   0,
-				OtherRemunerationsPerCapita: 0,
 				CrawlingTimestamp: timestamp{
 					Seconds: agencyMonthlyInfo.CrawlingTimestamp.GetSeconds(),
 					Nanos:   agencyMonthlyInfo.CrawlingTimestamp.GetNanos(),
@@ -788,12 +784,14 @@ func (h handler) GetAnnualSummary(c echo.Context) error {
 	var annualData []annualSummaryData
 	for _, s := range summaries {
 		baseRemPerMonth := s.BaseRemuneration / float64(s.NumMonthsWithData)
-		baseRemPerCapita := s.BaseRemuneration / float64(s.NumMonthsWithData) / float64(s.Count)
+		baseRemPerCapita := s.BaseRemuneration / float64(s.TotalCount)
 		otherRemPerMonth := s.OtherRemunerations / float64(s.NumMonthsWithData)
-		otherRemPerCapita := s.OtherRemunerations / float64(s.NumMonthsWithData) / float64(s.Count)
+		otherRemPerCapita := s.OtherRemunerations / float64(s.TotalCount)
 		annualData = append(annualData, annualSummaryData{
 			Year:                        s.Year,
-			Count:                       s.Count,
+			Count:                       s.AverageCount,
+			AverageCount:                s.AverageCount,
+			TotalCount:                  s.TotalCount,
 			BaseRemuneration:            s.BaseRemuneration,
 			BaseRemunerationPerMonth:    baseRemPerMonth,
 			BaseRemunerationPerCapita:   baseRemPerCapita,

--- a/uiapi/handlers.go
+++ b/uiapi/handlers.go
@@ -329,7 +329,7 @@ func (h handler) V2GetTotalsOfAgencyYear(c echo.Context) error {
 					Seconds: agencyMonthlyInfo.CrawlingTimestamp.GetSeconds(),
 					Nanos:   agencyMonthlyInfo.CrawlingTimestamp.GetNanos(),
 				},
-				TotalMembers: agencyMonthlyInfo.Summary.Count,
+				MemberCount: agencyMonthlyInfo.Summary.Count,
 			}
 			monthTotalsOfYear = append(monthTotalsOfYear, monthTotals)
 
@@ -789,7 +789,7 @@ func (h handler) GetAnnualSummary(c echo.Context) error {
 		otherRemPerCapita := s.OtherRemunerations / float64(s.TotalCount)
 		annualData = append(annualData, annualSummaryData{
 			Year:                        s.Year,
-			AverageCount:                s.AverageCount,
+			AverageMemberCount:          s.AverageCount,
 			BaseRemuneration:            s.BaseRemuneration,
 			BaseRemunerationPerMonth:    baseRemPerMonth,
 			BaseRemunerationPerCapita:   baseRemPerCapita,

--- a/uiapi/handlers.go
+++ b/uiapi/handlers.go
@@ -789,9 +789,7 @@ func (h handler) GetAnnualSummary(c echo.Context) error {
 		otherRemPerCapita := s.OtherRemunerations / float64(s.TotalCount)
 		annualData = append(annualData, annualSummaryData{
 			Year:                        s.Year,
-			Count:                       s.AverageCount,
 			AverageCount:                s.AverageCount,
-			TotalCount:                  s.TotalCount,
 			BaseRemuneration:            s.BaseRemuneration,
 			BaseRemunerationPerMonth:    baseRemPerMonth,
 			BaseRemunerationPerCapita:   baseRemPerCapita,

--- a/uiapi/models.go
+++ b/uiapi/models.go
@@ -243,9 +243,7 @@ type annualSummary struct {
 
 type annualSummaryData struct {
 	Year                        int     `json:"ano,omitempty"`
-	Count                       int     `json:"num_membros,omitempty"` // REMOVER POSTERIORMENTE
-	AverageCount                int     `json:"media_num_membros,omitempty"`
-	TotalCount                  int     `json:"total_num_membros,omitempty"`
+	AverageCount                int     `json:"num_membros,omitempty"`
 	BaseRemuneration            float64 `json:"remuneracao_base"`
 	BaseRemunerationPerMonth    float64 `json:"remuneracao_base_por_mes"`
 	BaseRemunerationPerCapita   float64 `json:"remuneracao_base_por_membro"`

--- a/uiapi/models.go
+++ b/uiapi/models.go
@@ -243,7 +243,9 @@ type annualSummary struct {
 
 type annualSummaryData struct {
 	Year                        int     `json:"ano,omitempty"`
-	Count                       int     `json:"num_membros,omitempty"`
+	Count                       int     `json:"num_membros,omitempty"` // REMOVER POSTERIORMENTE
+	AverageCount                int     `json:"media_num_membros,omitempty"`
+	TotalCount                  int     `json:"total_num_membros,omitempty"`
 	BaseRemuneration            float64 `json:"remuneracao_base"`
 	BaseRemunerationPerMonth    float64 `json:"remuneracao_base_por_mes"`
 	BaseRemunerationPerCapita   float64 `json:"remuneracao_base_por_membro"`

--- a/uiapi/models.go
+++ b/uiapi/models.go
@@ -148,12 +148,14 @@ type monthTotals struct {
 }
 
 type v2MonthTotals struct {
-	Error              *procError `json:"error,omitempty"`
-	Month              int        `json:"mes"`
-	TotalMembers       int        `json:"total_membros"`
-	BaseRemuneration   float64    `json:"remuneracao_base"`
-	OtherRemunerations float64    `json:"outras_remuneracoes"`
-	CrawlingTimestamp  timestamp  `json:"timestamp"`
+	Error                       *procError `json:"error,omitempty"`
+	Month                       int        `json:"mes"`
+	TotalMembers                int        `json:"total_membros"`
+	BaseRemuneration            float64    `json:"remuneracao_base"`
+	BaseRemunerationPerCapita   float64    `json:"remuneracao_base_por_membro"`
+	OtherRemunerations          float64    `json:"outras_remuneracoes"`
+	OtherRemunerationsPerCapita float64    `json:"outras_remuneracoes_por_membro"`
+	CrawlingTimestamp           timestamp  `json:"timestamp"`
 }
 
 type timestamp struct {
@@ -240,12 +242,16 @@ type annualSummary struct {
 }
 
 type annualSummaryData struct {
-	Year               int     `json:"ano,omitempty"`
-	Count              int     `json:"num_membros,omitempty"`
-	BaseRemuneration   float64 `json:"remuneracao_base"`
-	OtherRemunerations float64 `json:"outras_remuneracoes"`
-	NumMonthsWithData  int     `json:"meses_com_dados"`
-	Package            *backup `json:"package,omitempty"`
+	Year                        int     `json:"ano,omitempty"`
+	Count                       int     `json:"num_membros,omitempty"`
+	BaseRemuneration            float64 `json:"remuneracao_base"`
+	BaseRemunerationPerMonth    float64 `json:"remuneracao_base_por_mes"`
+	BaseRemunerationPerCapita   float64 `json:"remuneracao_base_por_membro"`
+	OtherRemunerations          float64 `json:"outras_remuneracoes"`
+	OtherRemunerationsPerMonth  float64 `json:"outras_remuneracoes_por_mes"`
+	OtherRemunerationsPerCapita float64 `json:"outras_remuneracoes_por_membro"`
+	NumMonthsWithData           int     `json:"meses_com_dados"`
+	Package                     *backup `json:"package,omitempty"`
 }
 
 type mensalRemuneration struct {

--- a/uiapi/models.go
+++ b/uiapi/models.go
@@ -150,7 +150,7 @@ type monthTotals struct {
 type v2MonthTotals struct {
 	Error                       *procError `json:"error,omitempty"`
 	Month                       int        `json:"mes"`
-	TotalMembers                int        `json:"total_membros"`
+	MemberCount                 int        `json:"total_membros"`
 	BaseRemuneration            float64    `json:"remuneracao_base"`
 	BaseRemunerationPerCapita   float64    `json:"remuneracao_base_por_membro"`
 	OtherRemunerations          float64    `json:"outras_remuneracoes"`
@@ -243,7 +243,7 @@ type annualSummary struct {
 
 type annualSummaryData struct {
 	Year                        int     `json:"ano,omitempty"`
-	AverageCount                int     `json:"num_membros,omitempty"`
+	AverageMemberCount          int     `json:"num_membros,omitempty"`
 	BaseRemuneration            float64 `json:"remuneracao_base"`
 	BaseRemunerationPerMonth    float64 `json:"remuneracao_base_por_mes"`
 	BaseRemunerationPerCapita   float64 `json:"remuneracao_base_por_membro"`

--- a/uiapi/uiapi_test.go
+++ b/uiapi/uiapi_test.go
@@ -1266,7 +1266,8 @@ func (g getAnnualSummary) testWhenDataExists(t *testing.T) {
 	agmi := []models.AnnualSummary{
 		{
 			Year:               2020,
-			Count:              214,
+			AverageCount:       214,
+			TotalCount:         2568,
 			BaseRemuneration:   10000,
 			OtherRemunerations: 1000,
 			NumMonthsWithData:  12,
@@ -1317,6 +1318,8 @@ func (g getAnnualSummary) testWhenDataExists(t *testing.T) {
 				{
 					"ano": 2020,
 					"num_membros": 214,
+					"media_num_membros": 214,
+					"total_num_membros": 2568,
 					"remuneracao_base": 10000,
 					"remuneracao_base_por_membro": 3.8940809968847354, 
 					"remuneracao_base_por_mes": 833.3333333333334,

--- a/uiapi/uiapi_test.go
+++ b/uiapi/uiapi_test.go
@@ -1121,13 +1121,15 @@ func (g getTotalsOfAgencyYear) testWhenDataExists(t *testing.T) {
 				"uf": "AL",
 				"twitter_handle": "tjaloficial",
 				"ouvidoria": "http://www.tjal.jus.br/ombudsman",
-				"url": "example.com/v1/orgao/tjal"
+				"url": "example.com/v2/orgao/tjal"
 			},
 			"meses": [
 				{
 					"mes": 1,
 					"outras_remuneracoes":1.9515865600000022e+06,
+					"outras_remuneracoes_por_membro":9119.563364485992,
 					"remuneracao_base":7.099024400000013e+06,
+					"remuneracao_base_por_membro":33173.01121495333,
 					"timestamp": {
 						"seconds": 1,
 						"nanos": 1
@@ -1196,7 +1198,7 @@ func (g getTotalsOfAgencyYear) testWhenMonthlyInfoDoesNotExist(t *testing.T) {
 					"uf": "AL",
 					"twitter_handle": "tjaloficial",
 					"ouvidoria": "http://www.tjal.jus.br/ombudsman",
-					"url": "example.com/v1/orgao/tjal"
+					"url": "example.com/v2/orgao/tjal"
 				}
 		}
 	`
@@ -1283,7 +1285,7 @@ func (g getAnnualSummary) testWhenDataExists(t *testing.T) {
 	e := echo.New()
 	request := httptest.NewRequest(
 		http.MethodGet,
-		"/uiapi/v1/orgao/resumo/:orgao",
+		"/uiapi/v2/orgao/resumo/:orgao",
 		nil,
 	)
 	recorder := httptest.NewRecorder()
@@ -1309,14 +1311,18 @@ func (g getAnnualSummary) testWhenDataExists(t *testing.T) {
 				"uf": "AL",
 				"twitter_handle": "tjaloficial",
 				"ouvidoria": "http://www.tjal.jus.br/ombudsman",
-				"url": "example.com/v1/orgao/tjal"
+				"url": "example.com/v2/orgao/tjal"
 			},
 			"dados_anuais": [
 				{
 					"ano": 2020,
 					"num_membros": 214,
 					"remuneracao_base": 10000,
+					"remuneracao_base_por_membro": 46.728971962616825, 
+					"remuneracao_base_por_mes": 833.3333333333334,
 					"outras_remuneracoes": 1000,
+					"outras_remuneracoes_por_membro": 4.672897196261682, 
+					"outras_remuneracoes_por_mes": 83.33333333333333,
 					"meses_com_dados": 12,
 					"package": {
 						"url": "https://dadosjusbr.org/download/tjal/datapackage/tjal-2020-1.zip",
@@ -1343,7 +1349,7 @@ func (g getAnnualSummary) testWhenAgencyDoesNotExist(t *testing.T) {
 	e := echo.New()
 	request := httptest.NewRequest(
 		http.MethodGet,
-		"/uiapi/v1/orgao/resumo/:orgao",
+		"/uiapi/v2/orgao/resumo/:orgao",
 		nil,
 	)
 	recorder := httptest.NewRecorder()
@@ -1377,7 +1383,7 @@ func (g getAnnualSummary) testWhenGetAnnualSummaryReturnsError(t *testing.T) {
 		UF:            "AL",
 		TwitterHandle: "tjaloficial",
 		Type:          "Estadual",
-		URL:           "example.com/v1/orgao/tjal",
+		URL:           "example.com/v2/orgao/tjal",
 		OmbudsmanURL:  "http://www.tjal.jus.br/ombudsman",
 	}
 	dbMock.EXPECT().Connect().Return(nil).Times(1)
@@ -1387,7 +1393,7 @@ func (g getAnnualSummary) testWhenGetAnnualSummaryReturnsError(t *testing.T) {
 	e := echo.New()
 	request := httptest.NewRequest(
 		http.MethodGet,
-		"/uiapi/v1/orgao/resumo/:orgao",
+		"/uiapi/v2/orgao/resumo/:orgao",
 		nil,
 	)
 	recorder := httptest.NewRecorder()
@@ -1421,7 +1427,7 @@ func (g getAnnualSummary) testWhenAgencyDoesNotHaveData(t *testing.T) {
 		UF:            "AL",
 		TwitterHandle: "tjaloficial",
 		Type:          "Estadual",
-		URL:           "example.com/v1/orgao/tjal",
+		URL:           "example.com/v2/orgao/tjal",
 		OmbudsmanURL:  "http://www.tjal.jus.br/ombudsman",
 	}
 	dbMock.EXPECT().Connect().Return(nil).Times(1)
@@ -1457,7 +1463,7 @@ func (g getAnnualSummary) testWhenAgencyDoesNotHaveData(t *testing.T) {
 				"uf": "AL",
 				"twitter_handle": "tjaloficial",
 				"ouvidoria": "http://www.tjal.jus.br/ombudsman",
-				"url": "example.com/v1/orgao/tjal"
+				"url": "example.com/v2/orgao/tjal"
 			}
 		}
 	`

--- a/uiapi/uiapi_test.go
+++ b/uiapi/uiapi_test.go
@@ -1318,8 +1318,6 @@ func (g getAnnualSummary) testWhenDataExists(t *testing.T) {
 				{
 					"ano": 2020,
 					"num_membros": 214,
-					"media_num_membros": 214,
-					"total_num_membros": 2568,
 					"remuneracao_base": 10000,
 					"remuneracao_base_por_membro": 3.8940809968847354, 
 					"remuneracao_base_por_mes": 833.3333333333334,

--- a/uiapi/uiapi_test.go
+++ b/uiapi/uiapi_test.go
@@ -1318,10 +1318,10 @@ func (g getAnnualSummary) testWhenDataExists(t *testing.T) {
 					"ano": 2020,
 					"num_membros": 214,
 					"remuneracao_base": 10000,
-					"remuneracao_base_por_membro": 46.728971962616825, 
+					"remuneracao_base_por_membro": 3.8940809968847354, 
 					"remuneracao_base_por_mes": 833.3333333333334,
 					"outras_remuneracoes": 1000,
-					"outras_remuneracoes_por_membro": 4.672897196261682, 
+					"outras_remuneracoes_por_membro": 0.3894080996884735, 
 					"outras_remuneracoes_por_mes": 83.33333333333333,
 					"meses_com_dados": 12,
 					"package": {


### PR DESCRIPTION
- Foram modificadas as rotas: `/uiapi/v2/orgao/totais/${id}/${year}` e `/v2/orgao/resumo/${id}`
- Passando a média mensal e a média per capita. 
- No caso do gráfico de anos, a média mensal per capita. 