### PR TITLE
Retornando licença-prêmio

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1046,6 +1046,9 @@ const docTemplate = `{
                 "auxilio_alimentacao": {
                     "type": "number"
                 },
+                "licenca_premio": {
+                    "type": "number"
+                },
                 "outras": {
                     "description": "valor agregado de outras rubricas não identificadas",
                     "type": "number"
@@ -1383,6 +1386,9 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "auxilio_alimentacao": {
+                    "type": "number"
+                },
+                "licenca_premio": {
                     "type": "number"
                 },
                 "outras": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1037,6 +1037,9 @@
                 "auxilio_alimentacao": {
                     "type": "number"
                 },
+                "licenca_premio": {
+                    "type": "number"
+                },
                 "outras": {
                     "description": "valor agregado de outras rubricas não identificadas",
                     "type": "number"
@@ -1374,6 +1377,9 @@
             "type": "object",
             "properties": {
                 "auxilio_alimentacao": {
+                    "type": "number"
+                },
+                "licenca_premio": {
                     "type": "number"
                 },
                 "outras": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -187,6 +187,8 @@ definitions:
     properties:
       auxilio_alimentacao:
         type: number
+      licenca_premio:
+        type: number
       outras:
         description: valor agregado de outras rubricas não identificadas
         type: number
@@ -413,6 +415,8 @@ definitions:
   uiapi.itemSummary:
     properties:
       auxilio_alimentacao:
+        type: number
+      licenca_premio:
         type: number
       outras:
         description: valor agregado de outras rubricas não identificadas

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/dadosjusbr/proto v0.0.0-20221212025627-91c60aa3cd12
-	github.com/dadosjusbr/storage v0.0.0-20240109194919-e8fa5bdec162
+	github.com/dadosjusbr/storage v0.0.0-20240122222419-3472161adddb
 	github.com/gocarina/gocsv v0.0.0-20220712153207-8b2118da4570
 	github.com/golang/mock v1.6.0
 	github.com/joho/godotenv v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -40,6 +40,8 @@ github.com/dadosjusbr/storage v0.0.0-20231106132314-7063d34ebc2d h1:vU6hL1gxD9fv
 github.com/dadosjusbr/storage v0.0.0-20231106132314-7063d34ebc2d/go.mod h1:JTg/Wu2+wn9SV1J19dDeEronive9J6QelMA7K6vLO8I=
 github.com/dadosjusbr/storage v0.0.0-20240109194919-e8fa5bdec162 h1:adRnuhh3Lvk4YClkZl3KRJYln3XmFr+ElGBArQt86LI=
 github.com/dadosjusbr/storage v0.0.0-20240109194919-e8fa5bdec162/go.mod h1:PszGy6CDoG3kNLjIsCmwD3MAWED7xL7U/OWj7ajsiHc=
+github.com/dadosjusbr/storage v0.0.0-20240122222419-3472161adddb h1:yCHr4P7e8kBCd7vEuqoaW7r737ukj6UGFXtwgERzNmg=
+github.com/dadosjusbr/storage v0.0.0-20240122222419-3472161adddb/go.mod h1:PszGy6CDoG3kNLjIsCmwD3MAWED7xL7U/OWj7ajsiHc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/papi/handlers.go
+++ b/papi/handlers.go
@@ -674,7 +674,7 @@ func (h handler) V2GetAggregateIndexesWithParams(c echo.Context) error {
 //	@Produce		json
 //	@Success		200			{object}	[]aggregateIndexesByGroup	"Requisição bem sucedida."
 //	@Failure		500			{string}	string						"Erro interno do servidor."
-//	@Router			/v2/indice 																													[get]
+//	@Router			/v2/indice 																																					[get]
 func (h handler) V2GetAggregateIndexes(c echo.Context) error {
 	agregado := c.QueryParam("agregado")
 	detalhe := c.QueryParam("detalhe")

--- a/papi/handlers.go
+++ b/papi/handlers.go
@@ -334,6 +334,7 @@ func (h handler) V2GetMonthlyInfo(c echo.Context) error {
 						},
 						ItemSummary: itemSummary{
 							FoodAllowance: monthlyInfo.Summary.ItemSummary.FoodAllowance,
+							BonusLicence:  monthlyInfo.Summary.ItemSummary.BonusLicence,
 							Others:        monthlyInfo.Summary.ItemSummary.Others,
 						},
 					},
@@ -458,6 +459,7 @@ func (h handler) GetMonthlyInfosByYear(c echo.Context) error {
 								},
 								ItemSummary: itemSummary{
 									FoodAllowance: mi.Summary.ItemSummary.FoodAllowance,
+									BonusLicence:  mi.Summary.ItemSummary.BonusLicence,
 									Others:        mi.Summary.ItemSummary.Others,
 								},
 							},
@@ -837,6 +839,7 @@ func (h handler) V2GetAllAgencyInformation(c echo.Context) error {
 						},
 						ItemSummary: itemSummary{
 							FoodAllowance: c.Summary.ItemSummary.FoodAllowance,
+							BonusLicence:  c.Summary.ItemSummary.BonusLicence,
 							Others:        c.Summary.ItemSummary.Others,
 						},
 					},

--- a/papi/handlers.go
+++ b/papi/handlers.go
@@ -334,7 +334,7 @@ func (h handler) V2GetMonthlyInfo(c echo.Context) error {
 						},
 						ItemSummary: itemSummary{
 							FoodAllowance: monthlyInfo.Summary.ItemSummary.FoodAllowance,
-							BonusLicence:  monthlyInfo.Summary.ItemSummary.BonusLicence,
+							BonusLicense:  monthlyInfo.Summary.ItemSummary.BonusLicense,
 							Others:        monthlyInfo.Summary.ItemSummary.Others,
 						},
 					},
@@ -459,7 +459,7 @@ func (h handler) GetMonthlyInfosByYear(c echo.Context) error {
 								},
 								ItemSummary: itemSummary{
 									FoodAllowance: mi.Summary.ItemSummary.FoodAllowance,
-									BonusLicence:  mi.Summary.ItemSummary.BonusLicence,
+									BonusLicense:  mi.Summary.ItemSummary.BonusLicense,
 									Others:        mi.Summary.ItemSummary.Others,
 								},
 							},
@@ -839,7 +839,7 @@ func (h handler) V2GetAllAgencyInformation(c echo.Context) error {
 						},
 						ItemSummary: itemSummary{
 							FoodAllowance: c.Summary.ItemSummary.FoodAllowance,
-							BonusLicence:  c.Summary.ItemSummary.BonusLicence,
+							BonusLicense:  c.Summary.ItemSummary.BonusLicense,
 							Others:        c.Summary.ItemSummary.Others,
 						},
 					},

--- a/papi/models.go
+++ b/papi/models.go
@@ -24,7 +24,7 @@ type summary struct {
 
 type itemSummary struct {
 	FoodAllowance float64 `json:"auxilio_alimentacao,omitempty"`
-	BonusLicence  float64 `json:"licenca_premio,omitempty"`
+	BonusLicense  float64 `json:"licenca_premio,omitempty"`
 	Others        float64 `json:"outras,omitempty"` // valor agregado de outras rubricas não identificadas
 }
 

--- a/papi/models.go
+++ b/papi/models.go
@@ -24,6 +24,7 @@ type summary struct {
 
 type itemSummary struct {
 	FoodAllowance float64 `json:"auxilio_alimentacao,omitempty"`
+	BonusLicence  float64 `json:"licenca_premio,omitempty"`
 	Others        float64 `json:"outras,omitempty"` // valor agregado de outras rubricas não identificadas
 }
 

--- a/uiapi/handlers.go
+++ b/uiapi/handlers.go
@@ -124,7 +124,7 @@ func (h handler) V2GetSummaryOfAgency(c echo.Context) error {
 		HasPrevious: time.Date(year, time.Month(month), 1, 0, 0, 0, 0, time.UTC).In(h.loc).After(time.Date(2018, 1, 1, 0, 0, 0, 0, time.UTC).In(h.loc)),
 		ItemSummary: itemSummary{
 			FoodAllowance: agencyMonthlyInfo.Summary.ItemSummary.FoodAllowance,
-			BonusLicence:  agencyMonthlyInfo.Summary.ItemSummary.BonusLicence,
+			BonusLicense:  agencyMonthlyInfo.Summary.ItemSummary.BonusLicense,
 			Others:        agencyMonthlyInfo.Summary.ItemSummary.Others,
 		},
 	}
@@ -341,7 +341,7 @@ func (h handler) V2GetTotalsOfAgencyYear(c echo.Context) error {
 				MemberCount: agencyMonthlyInfo.Summary.Count,
 				ItemSummary: itemSummary{
 					FoodAllowance: agencyMonthlyInfo.Summary.ItemSummary.FoodAllowance,
-					BonusLicence:  agencyMonthlyInfo.Summary.ItemSummary.BonusLicence,
+					BonusLicense:  agencyMonthlyInfo.Summary.ItemSummary.BonusLicense,
 					Others:        agencyMonthlyInfo.Summary.ItemSummary.Others,
 				},
 			}
@@ -598,7 +598,7 @@ func (h handler) V2GetGeneralRemunerationFromYear(c echo.Context) error {
 			Remunerations:      d.Remunerations,
 			ItemSummary: itemSummary{
 				FoodAllowance: d.ItemSummary.FoodAllowance,
-				BonusLicence:  d.ItemSummary.BonusLicence,
+				BonusLicense:  d.ItemSummary.BonusLicense,
 				Others:        d.ItemSummary.Others,
 			},
 		})
@@ -814,7 +814,7 @@ func (h handler) GetAnnualSummary(c echo.Context) error {
 		discountsRemPerCapita := s.Discounts / float64(s.TotalCount)
 		itemSummary := itemSummary{
 			FoodAllowance: s.ItemSummary.FoodAllowance,
-			BonusLicence:  s.ItemSummary.BonusLicence,
+			BonusLicense:  s.ItemSummary.BonusLicense,
 			Others:        s.ItemSummary.Others,
 		}
 		annualData = append(annualData, annualSummaryData{

--- a/uiapi/handlers.go
+++ b/uiapi/handlers.go
@@ -124,6 +124,7 @@ func (h handler) V2GetSummaryOfAgency(c echo.Context) error {
 		HasPrevious: time.Date(year, time.Month(month), 1, 0, 0, 0, 0, time.UTC).In(h.loc).After(time.Date(2018, 1, 1, 0, 0, 0, 0, time.UTC).In(h.loc)),
 		ItemSummary: itemSummary{
 			FoodAllowance: agencyMonthlyInfo.Summary.ItemSummary.FoodAllowance,
+			BonusLicence:  agencyMonthlyInfo.Summary.ItemSummary.BonusLicence,
 			Others:        agencyMonthlyInfo.Summary.ItemSummary.Others,
 		},
 	}
@@ -340,6 +341,7 @@ func (h handler) V2GetTotalsOfAgencyYear(c echo.Context) error {
 				MemberCount: agencyMonthlyInfo.Summary.Count,
 				ItemSummary: itemSummary{
 					FoodAllowance: agencyMonthlyInfo.Summary.ItemSummary.FoodAllowance,
+					BonusLicence:  agencyMonthlyInfo.Summary.ItemSummary.BonusLicence,
 					Others:        agencyMonthlyInfo.Summary.ItemSummary.Others,
 				},
 			}
@@ -596,6 +598,7 @@ func (h handler) V2GetGeneralRemunerationFromYear(c echo.Context) error {
 			Remunerations:      d.Remunerations,
 			ItemSummary: itemSummary{
 				FoodAllowance: d.ItemSummary.FoodAllowance,
+				BonusLicence:  d.ItemSummary.BonusLicence,
 				Others:        d.ItemSummary.Others,
 			},
 		})
@@ -811,6 +814,7 @@ func (h handler) GetAnnualSummary(c echo.Context) error {
 		discountsRemPerCapita := s.Discounts / float64(s.TotalCount)
 		itemSummary := itemSummary{
 			FoodAllowance: s.ItemSummary.FoodAllowance,
+			BonusLicence:  s.ItemSummary.BonusLicence,
 			Others:        s.ItemSummary.Others,
 		}
 		annualData = append(annualData, annualSummaryData{

--- a/uiapi/models.go
+++ b/uiapi/models.go
@@ -274,7 +274,7 @@ type annualSummaryData struct {
 
 type itemSummary struct {
 	FoodAllowance float64 `json:"auxilio_alimentacao,omitempty"`
-	BonusLicence  float64 `json:"licenca_premio,omitempty"`
+	BonusLicense  float64 `json:"licenca_premio,omitempty"`
 	Others        float64 `json:"outras,omitempty"` // valor agregado de outras rubricas não identificadas
 }
 

--- a/uiapi/models.go
+++ b/uiapi/models.go
@@ -274,6 +274,7 @@ type annualSummaryData struct {
 
 type itemSummary struct {
 	FoodAllowance float64 `json:"auxilio_alimentacao,omitempty"`
+	BonusLicence  float64 `json:"licenca_premio,omitempty"`
 	Others        float64 `json:"outras,omitempty"` // valor agregado de outras rubricas não identificadas
 }
 

--- a/uiapi/uiapi_test.go
+++ b/uiapi/uiapi_test.go
@@ -952,6 +952,7 @@ func (g getGenerealRemunerationFromYear) testWhenDataExists(t *testing.T) {
 			Remunerations:      10000,
 			ItemSummary: models.ItemSummary{
 				FoodAllowance: 100,
+				BonusLicence:  150,
 				Others:        200,
 			},
 		},
@@ -1001,6 +1002,7 @@ func (g getGenerealRemunerationFromYear) testWhenDataExists(t *testing.T) {
 				"remuneracoes": 10000,
 				"resumo_rubricas": {
 					"auxilio_alimentacao": 100,
+					"licenca_premio": 150,
 					"outras": 200
 				  }
 			},
@@ -1313,6 +1315,7 @@ func (g getAnnualSummary) testWhenDataExists(t *testing.T) {
 			},
 			ItemSummary: models.ItemSummary{
 				FoodAllowance: 100,
+				BonusLicence:  150,
 				Others:        200,
 			},
 		},
@@ -1377,6 +1380,7 @@ func (g getAnnualSummary) testWhenDataExists(t *testing.T) {
 					},
 					"resumo_rubricas": {
 						"auxilio_alimentacao": 100,
+						"licenca_premio": 150,
 						"outras": 200
 					  }
 				}

--- a/uiapi/uiapi_test.go
+++ b/uiapi/uiapi_test.go
@@ -952,7 +952,7 @@ func (g getGenerealRemunerationFromYear) testWhenDataExists(t *testing.T) {
 			Remunerations:      10000,
 			ItemSummary: models.ItemSummary{
 				FoodAllowance: 100,
-				BonusLicence:  150,
+				BonusLicense:  150,
 				Others:        200,
 			},
 		},
@@ -1315,7 +1315,7 @@ func (g getAnnualSummary) testWhenDataExists(t *testing.T) {
 			},
 			ItemSummary: models.ItemSummary{
 				FoodAllowance: 100,
-				BonusLicence:  150,
+				BonusLicense:  150,
 				Others:        200,
 			},
 		},


### PR DESCRIPTION
- Falta atualizar o storage (dadosjusbr/storage#127)
- retornando licença-prêmio
- a atualização da documentação inclui **_licenca_premio_** na sua versão atual, isto é, ainda não inclui as sugestões de modificações do Naza