### PR TITLE
retornando média por membro

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1347,6 +1347,23 @@ const docTemplate = `{
                 }
             }
         },
+        "uiapi.averagePerCapita": {
+            "type": "object",
+            "properties": {
+                "descontos": {
+                    "type": "number"
+                },
+                "outras_remuneracoes": {
+                    "type": "number"
+                },
+                "remuneracao_base": {
+                    "type": "number"
+                },
+                "remuneracoes": {
+                    "type": "number"
+                }
+            }
+        },
         "uiapi.backup": {
             "type": "object",
             "properties": {
@@ -1636,6 +1653,9 @@ const docTemplate = `{
             "properties": {
                 "ano": {
                     "type": "integer"
+                },
+                "media_por_membro": {
+                    "$ref": "#/definitions/uiapi.averagePerCapita"
                 },
                 "meses": {
                     "type": "array",

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1347,23 +1347,6 @@ const docTemplate = `{
                 }
             }
         },
-        "uiapi.averagePerCapita": {
-            "type": "object",
-            "properties": {
-                "descontos": {
-                    "type": "number"
-                },
-                "outras_remuneracoes": {
-                    "type": "number"
-                },
-                "remuneracao_base": {
-                    "type": "number"
-                },
-                "remuneracoes": {
-                    "type": "number"
-                }
-            }
-        },
         "uiapi.backup": {
             "type": "object",
             "properties": {
@@ -1467,6 +1450,23 @@ const docTemplate = `{
                 },
                 "resumo_rubricas": {
                     "$ref": "#/definitions/uiapi.itemSummary"
+                }
+            }
+        },
+        "uiapi.perCapitaData": {
+            "type": "object",
+            "properties": {
+                "descontos": {
+                    "type": "number"
+                },
+                "outras_remuneracoes": {
+                    "type": "number"
+                },
+                "remuneracao_base": {
+                    "type": "number"
+                },
+                "remuneracoes": {
+                    "type": "number"
                 }
             }
         },
@@ -1655,7 +1655,7 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "media_por_membro": {
-                    "$ref": "#/definitions/uiapi.averagePerCapita"
+                    "$ref": "#/definitions/uiapi.perCapitaData"
                 },
                 "meses": {
                     "type": "array",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1338,6 +1338,23 @@
                 }
             }
         },
+        "uiapi.averagePerCapita": {
+            "type": "object",
+            "properties": {
+                "descontos": {
+                    "type": "number"
+                },
+                "outras_remuneracoes": {
+                    "type": "number"
+                },
+                "remuneracao_base": {
+                    "type": "number"
+                },
+                "remuneracoes": {
+                    "type": "number"
+                }
+            }
+        },
         "uiapi.backup": {
             "type": "object",
             "properties": {
@@ -1627,6 +1644,9 @@
             "properties": {
                 "ano": {
                     "type": "integer"
+                },
+                "media_por_membro": {
+                    "$ref": "#/definitions/uiapi.averagePerCapita"
                 },
                 "meses": {
                     "type": "array",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1338,23 +1338,6 @@
                 }
             }
         },
-        "uiapi.averagePerCapita": {
-            "type": "object",
-            "properties": {
-                "descontos": {
-                    "type": "number"
-                },
-                "outras_remuneracoes": {
-                    "type": "number"
-                },
-                "remuneracao_base": {
-                    "type": "number"
-                },
-                "remuneracoes": {
-                    "type": "number"
-                }
-            }
-        },
         "uiapi.backup": {
             "type": "object",
             "properties": {
@@ -1458,6 +1441,23 @@
                 },
                 "resumo_rubricas": {
                     "$ref": "#/definitions/uiapi.itemSummary"
+                }
+            }
+        },
+        "uiapi.perCapitaData": {
+            "type": "object",
+            "properties": {
+                "descontos": {
+                    "type": "number"
+                },
+                "outras_remuneracoes": {
+                    "type": "number"
+                },
+                "remuneracao_base": {
+                    "type": "number"
+                },
+                "remuneracoes": {
+                    "type": "number"
                 }
             }
         },
@@ -1646,7 +1646,7 @@
                     "type": "integer"
                 },
                 "media_por_membro": {
-                    "$ref": "#/definitions/uiapi.averagePerCapita"
+                    "$ref": "#/definitions/uiapi.perCapitaData"
                 },
                 "meses": {
                     "type": "array",

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -389,17 +389,6 @@ definitions:
       resumo_rubricas:
         $ref: '#/definitions/uiapi.itemSummary'
     type: object
-  uiapi.averagePerCapita:
-    properties:
-      descontos:
-        type: number
-      outras_remuneracoes:
-        type: number
-      remuneracao_base:
-        type: number
-      remuneracoes:
-        type: number
-    type: object
   uiapi.backup:
     properties:
       hash:
@@ -469,6 +458,17 @@ definitions:
         type: number
       resumo_rubricas:
         $ref: '#/definitions/uiapi.itemSummary'
+    type: object
+  uiapi.perCapitaData:
+    properties:
+      descontos:
+        type: number
+      outras_remuneracoes:
+        type: number
+      remuneracao_base:
+        type: number
+      remuneracoes:
+        type: number
     type: object
   uiapi.procError:
     properties:
@@ -592,7 +592,7 @@ definitions:
       ano:
         type: integer
       media_por_membro:
-        $ref: '#/definitions/uiapi.averagePerCapita'
+        $ref: '#/definitions/uiapi.perCapitaData'
       meses:
         items:
           $ref: '#/definitions/uiapi.v2MonthTotals'

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -389,6 +389,17 @@ definitions:
       resumo_rubricas:
         $ref: '#/definitions/uiapi.itemSummary'
     type: object
+  uiapi.averagePerCapita:
+    properties:
+      descontos:
+        type: number
+      outras_remuneracoes:
+        type: number
+      remuneracao_base:
+        type: number
+      remuneracoes:
+        type: number
+    type: object
   uiapi.backup:
     properties:
       hash:
@@ -580,6 +591,8 @@ definitions:
     properties:
       ano:
         type: integer
+      media_por_membro:
+        $ref: '#/definitions/uiapi.averagePerCapita'
       meses:
         items:
           $ref: '#/definitions/uiapi.v2MonthTotals'

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/dadosjusbr/proto v0.0.0-20221212025627-91c60aa3cd12
-	github.com/dadosjusbr/storage v0.0.0-20240514131514-43ac5da3ae8a
+	github.com/dadosjusbr/storage v0.0.0-20240913213102-72765cc03b4e
 	github.com/gocarina/gocsv v0.0.0-20220712153207-8b2118da4570
 	github.com/golang/mock v1.6.0
 	github.com/joho/godotenv v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,8 @@ github.com/dadosjusbr/storage v0.0.0-20240315221019-5da10c81ab80 h1:mo6k/MAl6aF6
 github.com/dadosjusbr/storage v0.0.0-20240315221019-5da10c81ab80/go.mod h1:PszGy6CDoG3kNLjIsCmwD3MAWED7xL7U/OWj7ajsiHc=
 github.com/dadosjusbr/storage v0.0.0-20240514131514-43ac5da3ae8a h1:1LyzfsNzKgLjC4/cyQr+N724a4dcRCHB5yIauAnhhcI=
 github.com/dadosjusbr/storage v0.0.0-20240514131514-43ac5da3ae8a/go.mod h1:rIM/dbZMdrMfVnZgNgRNRRtsxfhSMH8S8X7MZEeKkrQ=
+github.com/dadosjusbr/storage v0.0.0-20240913213102-72765cc03b4e h1:RNcbmof3iPyJQNWbEPkNyKKffmQ8jkZa8QH/vZ5eJP0=
+github.com/dadosjusbr/storage v0.0.0-20240913213102-72765cc03b4e/go.mod h1:rIM/dbZMdrMfVnZgNgRNRRtsxfhSMH8S8X7MZEeKkrQ=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/papi/handlers.go
+++ b/papi/handlers.go
@@ -684,7 +684,7 @@ func (h handler) V2GetAggregateIndexesWithParams(c echo.Context) error {
 //	@Produce		json
 //	@Success		200			{object}	[]aggregateIndexesByGroup	"Requisição bem sucedida."
 //	@Failure		500			{string}	string						"Erro interno do servidor."
-//	@Router			/v2/indice 																																																																													[get]
+//	@Router			/v2/indice 																																																																																					[get]
 func (h handler) V2GetAggregateIndexes(c echo.Context) error {
 	agregado := c.QueryParam("agregado")
 	detalhe := c.QueryParam("detalhe")

--- a/papi/handlers.go
+++ b/papi/handlers.go
@@ -684,7 +684,7 @@ func (h handler) V2GetAggregateIndexesWithParams(c echo.Context) error {
 //	@Produce		json
 //	@Success		200			{object}	[]aggregateIndexesByGroup	"Requisição bem sucedida."
 //	@Failure		500			{string}	string						"Erro interno do servidor."
-//	@Router			/v2/indice 																																																																																					[get]
+//	@Router			/v2/indice 																																																																																													[get]
 func (h handler) V2GetAggregateIndexes(c echo.Context) error {
 	agregado := c.QueryParam("agregado")
 	detalhe := c.QueryParam("detalhe")

--- a/uiapi/handlers.go
+++ b/uiapi/handlers.go
@@ -413,11 +413,11 @@ func (h handler) V2GetTotalsOfAgencyYear(c echo.Context) error {
 		},
 		MonthTotals:    monthTotalsOfYear,
 		SummaryPackage: pkg,
-		AveragePerCapita: &averagePerCapita{
-			BaseRemunerationPerCapita:   strAveragePerCapita.BaseRemunerationPerCapita,
-			OtherRemunerationsPerCapita: strAveragePerCapita.OtherRemunerationsPerCapita,
-			DiscountsPerCapita:          strAveragePerCapita.DiscountsPerCapita,
-			RemunerationsPerCapita:      strAveragePerCapita.RemunerationsPerCapita,
+		AveragePerCapita: &perCapitaData{
+			BaseRemuneration:   strAveragePerCapita.BaseRemuneration,
+			OtherRemunerations: strAveragePerCapita.OtherRemunerations,
+			Discounts:          strAveragePerCapita.Discounts,
+			Remunerations:      strAveragePerCapita.Remunerations,
 		},
 	}
 	return c.JSON(http.StatusOK, agencyTotalsYear)

--- a/uiapi/models.go
+++ b/uiapi/models.go
@@ -124,10 +124,11 @@ type agencyTotalsYear struct {
 }
 
 type v2AgencyTotalsYear struct {
-	Year           int             `json:"ano,omitempty"`
-	Agency         *agency         `json:"orgao,omitempty"`
-	MonthTotals    []v2MonthTotals `json:"meses,omitempty"`
-	SummaryPackage *backup         `json:"package,omitempty"`
+	Year             int               `json:"ano,omitempty"`
+	Agency           *agency           `json:"orgao,omitempty"`
+	AveragePerCapita *averagePerCapita `json:"media_por_membro,omitempty"`
+	MonthTotals      []v2MonthTotals   `json:"meses,omitempty"`
+	SummaryPackage   *backup           `json:"package,omitempty"`
 }
 
 type backup struct {
@@ -291,4 +292,11 @@ type mensalRemuneration struct {
 	Discounts          float64     `json:"descontos"`
 	Remunerations      float64     `json:"remuneracoes"`
 	ItemSummary        itemSummary `json:"resumo_rubricas"`
+}
+
+type averagePerCapita struct {
+	BaseRemunerationPerCapita   float64 `json:"remuneracao_base"`
+	OtherRemunerationsPerCapita float64 `json:"outras_remuneracoes"`
+	DiscountsPerCapita          float64 `json:"descontos"`
+	RemunerationsPerCapita      float64 `json:"remuneracoes"`
 }

--- a/uiapi/models.go
+++ b/uiapi/models.go
@@ -124,11 +124,11 @@ type agencyTotalsYear struct {
 }
 
 type v2AgencyTotalsYear struct {
-	Year             int               `json:"ano,omitempty"`
-	Agency           *agency           `json:"orgao,omitempty"`
-	AveragePerCapita *averagePerCapita `json:"media_por_membro,omitempty"`
-	MonthTotals      []v2MonthTotals   `json:"meses,omitempty"`
-	SummaryPackage   *backup           `json:"package,omitempty"`
+	Year             int             `json:"ano,omitempty"`
+	Agency           *agency         `json:"orgao,omitempty"`
+	AveragePerCapita *perCapitaData  `json:"media_por_membro,omitempty"`
+	MonthTotals      []v2MonthTotals `json:"meses,omitempty"`
+	SummaryPackage   *backup         `json:"package,omitempty"`
 }
 
 type backup struct {
@@ -294,9 +294,9 @@ type mensalRemuneration struct {
 	ItemSummary        itemSummary `json:"resumo_rubricas"`
 }
 
-type averagePerCapita struct {
-	BaseRemunerationPerCapita   float64 `json:"remuneracao_base"`
-	OtherRemunerationsPerCapita float64 `json:"outras_remuneracoes"`
-	DiscountsPerCapita          float64 `json:"descontos"`
-	RemunerationsPerCapita      float64 `json:"remuneracoes"`
+type perCapitaData struct {
+	BaseRemuneration   float64 `json:"remuneracao_base"`
+	OtherRemunerations float64 `json:"outras_remuneracoes"`
+	Discounts          float64 `json:"descontos"`
+	Remunerations      float64 `json:"remuneracoes"`
 }

--- a/uiapi/uiapi_test.go
+++ b/uiapi/uiapi_test.go
@@ -1141,10 +1141,20 @@ func (g getTotalsOfAgencyYear) testWhenDataExists(t *testing.T) {
 			OmbudsmanURL:  "http://www.tjal.jus.br/ombudsman",
 		},
 	}
+	avg := models.AveragePerCapita{
+		ID:                          "tjal",
+		Year:                        2020,
+		BaseRemunerationPerCapita:   33173.01121495333,
+		OtherRemunerationsPerCapita: 9119.563364485992,
+		DiscountsPerCapita:          10382.615233644861,
+		RemunerationsPerCapita:      33173.01121495333,
+	}
+
 	dbMock.EXPECT().Connect().Return(nil).Times(1)
 	dbMock.EXPECT().GetAgency("tjal").Return(&agencies[0], nil).Times(1)
 	dbMock.EXPECT().GetMonthlyInfo([]models.Agency{{ID: "tjal"}}, 2020).Return(map[string][]models.AgencyMonthlyInfo{"tjal": agmi}, nil).Times(1)
 	fsMock.EXPECT().GetFile("tjal/datapackage/tjal-2020.zip").Return(agmi[0].Package, nil)
+	dbMock.EXPECT().GetAveragePerCapita("tjal", 2020).Return(&avg, nil).Times(1)
 
 	e := echo.New()
 	request := httptest.NewRequest(
@@ -1178,6 +1188,12 @@ func (g getTotalsOfAgencyYear) testWhenDataExists(t *testing.T) {
 				"ouvidoria": "http://www.tjal.jus.br/ombudsman",
 				"url": "example.com/v2/orgao/tjal"
 			},
+			"media_por_membro": {
+				"remuneracao_base": 33173.01121495333,
+				"outras_remuneracoes": 9119.563364485992,
+				"descontos": 10382.615233644861,
+				"remuneracoes": 33173.01121495333
+			  },
 			"meses": [
 				{
 					"mes": 1,
@@ -1232,10 +1248,20 @@ func (g getTotalsOfAgencyYear) testWhenMonthlyInfoDoesNotExist(t *testing.T) {
 		TwitterHandle: "tjaloficial",
 		OmbudsmanURL:  "http://www.tjal.jus.br/ombudsman",
 	}
+	avg := models.AveragePerCapita{
+		ID:                          "tjal",
+		Year:                        2020,
+		BaseRemunerationPerCapita:   0,
+		OtherRemunerationsPerCapita: 0,
+		DiscountsPerCapita:          0,
+		RemunerationsPerCapita:      0,
+	}
+
 	dbMock.EXPECT().Connect().Return(nil).Times(1)
 	dbMock.EXPECT().GetAgency("tjal").Return(&agency, nil).Times(1)
 	dbMock.EXPECT().GetMonthlyInfo([]models.Agency{{ID: "tjal"}}, 2020).Return(nil, nil).Times(1)
 	fsMock.EXPECT().GetFile("tjal/datapackage/tjal-2020.zip").Return(nil, nil).Times(1)
+	dbMock.EXPECT().GetAveragePerCapita("tjal", 2020).Return(&avg, nil).Times(1)
 
 	e := echo.New()
 	request := httptest.NewRequest(
@@ -1268,6 +1294,12 @@ func (g getTotalsOfAgencyYear) testWhenMonthlyInfoDoesNotExist(t *testing.T) {
 					"twitter_handle": "tjaloficial",
 					"ouvidoria": "http://www.tjal.jus.br/ombudsman",
 					"url": "example.com/v2/orgao/tjal"
+				},
+				"media_por_membro": {
+					"remuneracao_base": 0,
+					"outras_remuneracoes": 0,
+					"descontos": 0,
+					"remuneracoes": 0
 				}
 		}
 	`
@@ -1334,14 +1366,18 @@ func (g getAnnualSummary) testWhenDataExists(t *testing.T) {
 	}
 	agmi := []models.AnnualSummary{
 		{
-			Year:               2020,
-			AverageCount:       214,
-			TotalCount:         2568,
-			BaseRemuneration:   10000,
-			OtherRemunerations: 1000,
-			Discounts:          1000,
-			Remunerations:      10000,
-			NumMonthsWithData:  12,
+			Year:                        2020,
+			AverageCount:                214,
+			TotalCount:                  2568,
+			BaseRemuneration:            10000,
+			BaseRemunerationPerCapita:   3.8940809968847354,
+			OtherRemunerations:          1000,
+			OtherRemunerationsPerCapita: 0.3894080996884735,
+			Discounts:                   1000,
+			DiscountsPerCapita:          0.3894080996884735,
+			Remunerations:               10000,
+			RemunerationsPerCapita:      3.8940809968847354,
+			NumMonthsWithData:           12,
 			Package: &models.Backup{
 				URL:  "https://dadosjusbr.org/download/tjal/datapackage/tjal-2020-1.zip",
 				Hash: "4d7ca8986101673aea060ac1d8e5a529",

--- a/uiapi/uiapi_test.go
+++ b/uiapi/uiapi_test.go
@@ -1141,13 +1141,13 @@ func (g getTotalsOfAgencyYear) testWhenDataExists(t *testing.T) {
 			OmbudsmanURL:  "http://www.tjal.jus.br/ombudsman",
 		},
 	}
-	avg := models.AveragePerCapita{
-		ID:                          "tjal",
-		Year:                        2020,
-		BaseRemunerationPerCapita:   33173.01121495333,
-		OtherRemunerationsPerCapita: 9119.563364485992,
-		DiscountsPerCapita:          10382.615233644861,
-		RemunerationsPerCapita:      33173.01121495333,
+	avg := models.PerCapitaData{
+		AgencyID:           "tjal",
+		Year:               2020,
+		BaseRemuneration:   33173.01121495333,
+		OtherRemunerations: 9119.563364485992,
+		Discounts:          10382.615233644861,
+		Remunerations:      33173.01121495333,
 	}
 
 	dbMock.EXPECT().Connect().Return(nil).Times(1)
@@ -1248,13 +1248,13 @@ func (g getTotalsOfAgencyYear) testWhenMonthlyInfoDoesNotExist(t *testing.T) {
 		TwitterHandle: "tjaloficial",
 		OmbudsmanURL:  "http://www.tjal.jus.br/ombudsman",
 	}
-	avg := models.AveragePerCapita{
-		ID:                          "tjal",
-		Year:                        2020,
-		BaseRemunerationPerCapita:   0,
-		OtherRemunerationsPerCapita: 0,
-		DiscountsPerCapita:          0,
-		RemunerationsPerCapita:      0,
+	avg := models.PerCapitaData{
+		AgencyID:           "tjal",
+		Year:               2020,
+		BaseRemuneration:   0,
+		OtherRemunerations: 0,
+		Discounts:          0,
+		Remunerations:      0,
 	}
 
 	dbMock.EXPECT().Connect().Return(nil).Times(1)


### PR DESCRIPTION
- Como discutido anteriormente, estamos adotando um novo cálculo para a média por membro dos dados anuais.
- Isso também consolida os dados do site, uma vez que atualmente aparecem médias diferentes dependendo da página.
- Falta atualizar versão do storage: dadosjusbr/storage#138