### PR TITLE
chore: update CORS configuration to allow access from www origin

### DIFF
--- a/main.go
+++ b/main.go
@@ -152,8 +152,6 @@ func main() {
 		uiAPIGroup.Use(nrecho.Middleware(nr))
 		uiAPIGroup.Use(middleware.CORSWithConfig(middleware.CORSConfig{
 			AllowOrigins: []string{
-				"https://dadosjusbr.com",
-				"http://dadosjusbr.com",
 				"https://dadosjusbr.org",
 				"http://dadosjusbr.org",
 				"https://www.dadosjusbr.org",

--- a/main.go
+++ b/main.go
@@ -158,8 +158,8 @@ func main() {
 				"http://dadosjusbr.org",
 				"https://www.dadosjusbr.org",
 				"http://www.dadosjusbr.org",
-				"https://dadosjusbr-site-novo.herokuapp.com",
-				"http://dadosjusbr-site-novo.herokuapp.com",
+				"http://dadosjusbr-site-v2.us-east-1.elasticbeanstalk.com",
+				"http://www.dadosjusbr-site-v2.us-east-1.elasticbeanstalk.com",
 			},
 			AllowHeaders: []string{echo.HeaderOrigin, echo.HeaderContentType, echo.HeaderAccept, echo.HeaderContentLength},
 		}))

--- a/main.go
+++ b/main.go
@@ -82,10 +82,10 @@ func newS3Client(c config) (*file_storage.S3Client, error) {
 	return s3Client, nil
 }
 
-//	@title			API do dadosjusbr.org
-//	@version		1.0
-//	@contact.name	DadosJusBr
-//	@contact.url	https://dadosjusbr.org
+// @title			API do dadosjusbr.org
+// @version			1.0
+// @contact.name	DadosJusBr
+// @contact.url		https://dadosjusbr.org
 func main() {
 	godotenv.Load() // There is no problem if the .env can not be loaded.
 	l, err := time.LoadLocation("America/Sao_Paulo")
@@ -151,7 +151,16 @@ func main() {
 		}
 		uiAPIGroup.Use(nrecho.Middleware(nr))
 		uiAPIGroup.Use(middleware.CORSWithConfig(middleware.CORSConfig{
-			AllowOrigins: []string{"https://dadosjusbr.com", "http://dadosjusbr.com", "https://dadosjusbr.org", "http://dadosjusbr.org", "https://dadosjusbr-site-novo.herokuapp.com", "http://dadosjusbr-site-novo.herokuapp.com"},
+			AllowOrigins: []string{
+				"https://dadosjusbr.com",
+				"http://dadosjusbr.com",
+				"https://dadosjusbr.org",
+				"http://dadosjusbr.org",
+				"https://www.dadosjusbr.org",
+				"http://www.dadosjusbr.org",
+				"https://dadosjusbr-site-novo.herokuapp.com",
+				"http://dadosjusbr-site-novo.herokuapp.com",
+			},
 			AllowHeaders: []string{echo.HeaderOrigin, echo.HeaderContentType, echo.HeaderAccept, echo.HeaderContentLength},
 		}))
 		log.Println("Using production CORS")


### PR DESCRIPTION
### Concedendo permissão para que a URL www.dadosjusbr.org também consiga fazer requisições na API
 
Dia 18/02, @talitalobo reportou que o site não estava funcionando (como mostrado na imagem abaixo), mas ao abrir o site em minha máquina estava tudo normal. Demorei bastante para descobrir o motivo de não conseguir reproduzir o erro, até que notei algo esquisito.

Ao entrar no site pelo link [dadosjusbr.org](dadosjusbr.org) o conteúdo se comporta normalmente, o que não acontece se você entrar pelo link www.dadosjusbr.org. Como a origem é diferente, a API bloqueia chamadas vindas dessa URL, mesmo as duas estando configuradas para redirecionar para o mesmo conteúdo na Cloudflare. Por isso ocorre o erro de CORS (Cross-Origin Resource Sharing).

![Captura de Tela 2025-02-18 às 15 38 04](https://github.com/user-attachments/assets/e87b9253-e4c0-408a-9a8f-774a38bafb7c)
